### PR TITLE
Issue 3 - add support for MW 1.43

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             php_version: 7.4
             database_type: mysql
             database_image: "mysql:5.7"
-            coverage: true
+            coverage: false
             experimental: false
           - mediawiki_version: '1.39'
             php_version: 8.1
@@ -33,7 +33,7 @@ jobs:
             php_version: 8.1
             database_type: mysql
             database_image: "mysql:8"
-            coverage: false
+            coverage: true
             experimental: false
           - mediawiki_version: '1.41'
             php_version: 8.1
@@ -42,11 +42,18 @@ jobs:
             coverage: false
             experimental: false
           - mediawiki_version: '1.42'
-            php_version: 8.1
+            php_version: 8.2
             database_type: mysql
             database_image: "mysql:8"
             coverage: false
             experimental: false
+          - mediawiki_version: '1.43'
+            php_version: 8.2
+            database_type: mysql
+            database_image: "mariadb:11.2"
+            coverage: false
+            experimental: false
+            
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}
       PHP_VERSION: ${{ matrix.php_version }}


### PR DESCRIPTION
This PR is related to the issue #3.

This PR contains: 

- added support for MW 1.43
- coverage upload set for MW 1.40 instead of MW 1.35